### PR TITLE
set the meta role name and add some galaxy tags

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: 'sqlite'
   author: 'Adfinis SyGroup AG'
   description: 'Install and manage sqlite.'
   company: 'Adfinis SyGroup AG'
@@ -23,4 +24,6 @@ galaxy_info:
       versions:
         - 6
         - 7
-  galaxy_tags: []
+  galaxy_tags:
+    - sqlite
+    - sql


### PR DESCRIPTION
##### SUMMARY
The sqlite Ansible Galaxy role has a stupid name and there are no tags in the meta file specified.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request